### PR TITLE
add macros for adaptive the previous kernel api(vm_fault_t). #6

### DIFF
--- a/vmx.c
+++ b/vmx.c
@@ -4,6 +4,7 @@
 #include <linux/mm.h>
 #include <linux/anon_inodes.h>
 #include <linux/uaccess.h>
+#include <linux/version.h>
 
 #include "vmx.h"
 #include "config.h"
@@ -515,7 +516,11 @@ static long vmm_vcpu_ioctl(struct file *filp, unsigned int ioctl,
 	return r;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
+static int vmm_vcpu_page_fault(struct vm_fault *vmf)
+#else
 static vm_fault_t vmm_vcpu_page_fault(struct vm_fault *vmf)
+#endif
 {
 	struct vcpu *vcpu = vmf->vma->vm_file->private_data;
 	struct page *page;


### PR DESCRIPTION
This patch makes be able to build with older version.
I tested with 
```
$ uname - a
Linux archlinux 4.14.113 #1 SMP PREEMPT Sun Apr 21 13:48:41 JST 2019 x86_64 GNU/Linux │
```
close #6 